### PR TITLE
add isReservedWordES5 and isReservedWordES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,34 @@ Return true if provided code can be the trailing character of ECMA262 Identifier
 
 #### keyword.isKeywordES5(id, strict)
 
-Return true if provided identifier string is one of Keywords in ECMA262 5.1. They are formally defined in ECMA262.
-If strict flag is true, this function additionally checks whether id is keyword under strict mode.
+Returns `true` if provided identifier string is a Keyword or Future Reserved Word
+in ECMA262 edition 5.1. They are formally defined in ECMA262 sections
+[7.6.1.1](http://es5.github.io/#x7.6.1.1) and [7.6.1.2](http://es5.github.io/#x7.6.1.2),
+respectively. If the `strict` flag is truthy, this function additionally checks whether
+`id` is a Keyword or Future Reserved Word under strict mode.
 
 #### keyword.isKeywordES6(id, strict)
 
-Return true if provided identifier string is one of Keywords in ECMA262 6. They are formally defined in ECMA262.
-If strict flag is true, this function additionally checks whether id is keyword under strict mode.
+Returns `true` if provided identifier string is a Keyword or Future Reserved Word
+in ECMA262 edition 6. They are formally defined in ECMA262 sections
+[11.6.2.1](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-keywords) and
+[11.6.2.2](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-future-reserved-words),
+respectively. If the `strict` flag is truthy, this function additionally checks whether
+`id` is a Keyword or Future Reserved Word under strict mode.
+
+#### keyword.isReservedWordES5(id, strict)
+
+Returns `true` if provided identifier string is a Reserved Word in ECMA262 edition 5.1.
+They are formally defined in ECMA262 section [7.6.1](http://es5.github.io/#x7.6.1).
+If the `strict` flag is truthy, this function additionally checks whether `id`
+is a Reserved Word under strict mode.
+
+#### keyword.isReservedWordES6(id, strict)
+
+Returns `true` if provided identifier string is a Reserved Word in ECMA262 edition 6.
+They are formally defined in ECMA262 section [11.6.2](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reserved-words).
+If the `strict` flag is truthy, this function additionally checks whether `id`
+is a Reserved Word under strict mode.
 
 #### keyword.isRestrictedWord(id)
 

--- a/lib/keyword.js
+++ b/lib/keyword.js
@@ -82,6 +82,14 @@
         }
     }
 
+    function isReservedWordES5(id, strict) {
+        return id === 'null' || id === 'true' || id === 'false' || isKeywordES5(id, strict);
+    }
+
+    function isReservedWordES6(id, strict) {
+        return id === 'null' || id === 'true' || id === 'false' || isKeywordES6(id, strict);
+    }
+
     function isRestrictedWord(id) {
         return id === 'eval' || id === 'arguments';
     }
@@ -110,6 +118,8 @@
     module.exports = {
         isKeywordES5: isKeywordES5,
         isKeywordES6: isKeywordES6,
+        isReservedWordES5: isReservedWordES5,
+        isReservedWordES6: isReservedWordES6,
         isRestrictedWord: isRestrictedWord,
         isIdentifierName: isIdentifierName
     };

--- a/test/keyword.coffee
+++ b/test/keyword.coffee
@@ -115,6 +115,7 @@ describe 'keyword', ->
             for word in words
                 expect(esutils.keyword.isKeywordES6(word, yes)).to.be.false
 
+
     describe 'isKeywordES5', ->
         it 'returns true if provided string is keyword under non-strict mode', ->
             for word in KW
@@ -156,6 +157,113 @@ describe 'keyword', ->
 
             for word in words
                 expect(esutils.keyword.isKeywordES5(word, yes)).to.be.false
+
+
+    describe 'isReservedWordES6', ->
+        it 'returns true for null/boolean values', ->
+            expect(esutils.keyword.isReservedWordES6('null', no)).to.be.true
+            expect(esutils.keyword.isReservedWordES6('null', yes)).to.be.true
+            expect(esutils.keyword.isReservedWordES6('true', no)).to.be.true
+            expect(esutils.keyword.isReservedWordES6('true', yes)).to.be.true
+            expect(esutils.keyword.isReservedWordES6('false', no)).to.be.true
+            expect(esutils.keyword.isReservedWordES6('false', yes)).to.be.true
+
+        # isReservedWordES6 has the same properties as isKeywordES6
+
+        it 'returns true if provided string is keyword under non-strict mode', ->
+            for word in KW
+                expect(esutils.keyword.isReservedWordES6(word, no)).to.be.true
+
+            expect(esutils.keyword.isReservedWordES6('yield', no)).to.be.true
+
+        it 'returns false if provided string is not keyword under non-strict mode', ->
+            words = [
+                'hello'
+                '20'
+                '$'
+                'ゆゆ式'
+            ]
+
+            for word in words
+                expect(esutils.keyword.isReservedWordES6(word, no)).to.be.false
+
+            for word in SRW
+                expect(esutils.keyword.isReservedWordES6(word, no)).to.be.false
+
+        it 'returns true if provided string is keyword under strict mode', ->
+            for word in KW
+                expect(esutils.keyword.isReservedWordES6(word, yes)).to.be.true
+
+            expect(esutils.keyword.isReservedWordES6('yield', yes)).to.be.true
+
+            for word in SRW
+                expect(esutils.keyword.isReservedWordES6(word, yes)).to.be.true
+
+
+        it 'returns false if provided string is not keyword under strict mode', ->
+            words = [
+                'hello'
+                '20'
+                '$'
+                'ゆゆ式'
+            ]
+
+            for word in words
+                expect(esutils.keyword.isReservedWordES6(word, yes)).to.be.false
+
+
+    describe 'isReservedWordES5', ->
+        it 'returns true for null/boolean values', ->
+            expect(esutils.keyword.isReservedWordES5('null', no)).to.be.true
+            expect(esutils.keyword.isReservedWordES5('null', yes)).to.be.true
+            expect(esutils.keyword.isReservedWordES5('true', no)).to.be.true
+            expect(esutils.keyword.isReservedWordES5('true', yes)).to.be.true
+            expect(esutils.keyword.isReservedWordES5('false', no)).to.be.true
+            expect(esutils.keyword.isReservedWordES5('false', yes)).to.be.true
+
+        # isReservedWordES5 has the same properties as isKeywordES5
+
+        it 'returns true if provided string is keyword under non-strict mode', ->
+            for word in KW
+                expect(esutils.keyword.isReservedWordES5(word, no)).to.be.true
+
+        it 'returns false if provided string is not keyword under non-strict mode', ->
+            words = [
+                'hello'
+                '20'
+                '$'
+                'ゆゆ式'
+            ]
+
+            for word in words
+                expect(esutils.keyword.isReservedWordES5(word, no)).to.be.false
+
+            for word in SRW
+                expect(esutils.keyword.isReservedWordES5(word, no)).to.be.false
+
+            expect(esutils.keyword.isReservedWordES5('yield', no)).to.be.false
+
+        it 'returns true if provided string is keyword under strict mode', ->
+            for word in KW
+                expect(esutils.keyword.isReservedWordES5(word, yes)).to.be.true
+
+            expect(esutils.keyword.isReservedWordES5('yield', yes)).to.be.true
+
+            for word in SRW
+                expect(esutils.keyword.isReservedWordES5(word, yes)).to.be.true
+
+
+        it 'returns false if provided string is not keyword under strict mode', ->
+            words = [
+                'hello'
+                '20'
+                '$'
+                'ゆゆ式'
+            ]
+
+            for word in words
+                expect(esutils.keyword.isReservedWordES5(word, yes)).to.be.false
+
 
     describe 'isRestrictedWord', ->
         it 'returns true if provided string is "eval" or "arguments"', ->


### PR DESCRIPTION
This exposes the spec concept of ReservedWord, detailed in ES5 section 7.6.1 and current ES6 draft (revision 25) section 11.6.2.
