### PR TITLE
fixes #7: add initial AST functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,31 @@
 esutils ([esutils](http://github.com/Constellation/esutils)) is
 utility box for ECMAScript language tools.
 
-### Functions
+### API
+
+### ast
+
+#### ast.isExpression(node)
+
+Returns true if `node` is an Expression as defined in ECMA262 edition 5.1 section
+[11](https://es5.github.io/#x11).
+
+#### ast.isStatement(node)
+
+Returns true if `node` is a Statement as defined in ECMA262 edition 5.1 section
+[12](https://es5.github.io/#x12).
+
+#### ast.isIterationStatement(node)
+
+Returns true if `node` is an IterationStatement as defined in ECMA262 edition
+5.1 section [12.6](https://es5.github.io/#x12.6).
+
+#### ast.isStatement(node)
+
+Returns true if `node` is a SourceElement as defined in ECMA262 edition 5.1
+section [14](https://es5.github.io/#x14).
+
+### code
 
 #### code.isDecimalDigit(code)
 

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1,0 +1,101 @@
+/*
+  Copyright (C) 2013 Yusuke Suzuki <utatane.tea@gmail.com>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+(function () {
+    'use strict';
+
+    function isExpression(node) {
+        if (node == null) { return false; }
+        switch (node.type) {
+            case 'ArrayExpression':
+            case 'AssignmentExpression':
+            case 'BinaryExpression':
+            case 'CallExpression':
+            case 'ConditionalExpression':
+            case 'FunctionExpression':
+            case 'Identifier':
+            case 'Literal':
+            case 'LogicalExpression':
+            case 'MemberExpression':
+            case 'NewExpression':
+            case 'ObjectExpression':
+            case 'SequenceExpression':
+            case 'ThisExpression':
+            case 'UnaryExpression':
+            case 'UpdateExpression':
+                return true;
+        }
+        return false;
+    }
+
+    function isIterationStatement(node) {
+        if (node == null) { return false; }
+        switch (node.type) {
+            case 'DoWhileStatement':
+            case 'ForInStatement':
+            case 'ForStatement':
+            case 'WhileStatement':
+                return true;
+        }
+        return false;
+    }
+
+    function isStatement(node) {
+        if (node == null) { return false; }
+        switch (node.type) {
+            case 'BlockStatement':
+            case 'BreakStatement':
+            case 'ContinueStatement':
+            case 'DebuggerStatement':
+            case 'DoWhileStatement':
+            case 'EmptyStatement':
+            case 'ExpressionStatement':
+            case 'ForInStatement':
+            case 'ForStatement':
+            case 'IfStatement':
+            case 'LabeledStatement':
+            case 'ReturnStatement':
+            case 'SwitchStatement':
+            case 'ThrowStatement':
+            case 'TryStatement':
+            case 'VariableDeclaration':
+            case 'WhileStatement':
+            case 'WithStatement':
+                return true;
+        }
+        return false;
+    }
+
+    function isSourceElement(node) {
+      return isStatement(node) || node != null && node.type === 'FunctionDeclaration';
+    }
+
+    module.exports = {
+        isExpression: isExpression,
+        isStatement: isStatement,
+        isIterationStatement: isIterationStatement,
+        isSourceElement: isSourceElement
+    };
+}());
+/* vim: set sw=4 ts=4 et tw=80 : */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,6 +26,7 @@
 (function () {
     'use strict';
 
+    exports.ast = require('./ast');
     exports.code = require('./code');
     exports.keyword = require('./keyword');
 }());

--- a/test/ast.coffee
+++ b/test/ast.coffee
@@ -1,0 +1,100 @@
+# Copyright (C) 2013 Yusuke Suzuki <utatane.tea@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'use strict'
+
+expect = require('chai').expect
+esutils = require '../'
+
+describe 'ast', ->
+    describe 'isExpression', ->
+        it 'returns false if input is not node', ->
+            expect(esutils.ast.isExpression(0)).to.be.false
+            expect(esutils.ast.isExpression(null)).to.be.false
+            expect(esutils.ast.isExpression(undefined)).to.be.false
+            expect(esutils.ast.isExpression({})).to.be.false
+            expect(esutils.ast.isExpression({type: null})).to.be.false
+            expect(esutils.ast.isExpression({type: undefined})).to.be.false
+
+        it 'returns true if provided node is expression', ->
+            expect(esutils.ast.isExpression({type: "ThisExpression"})).to.be.true
+            expect(esutils.ast.isExpression({type: "Literal", value: 0})).to.be.true
+
+        it 'returns false if provided node is not expression', ->
+            expect(esutils.ast.isExpression({type: "ExpressionStatement"})).to.be.false
+            expect(esutils.ast.isExpression({type: "Program"})).to.be.false
+
+
+    describe 'isIterationStatement', ->
+        it 'returns false if input is not node', ->
+            expect(esutils.ast.isIterationStatement(0)).to.be.false
+            expect(esutils.ast.isIterationStatement(null)).to.be.false
+            expect(esutils.ast.isIterationStatement(undefined)).to.be.false
+            expect(esutils.ast.isIterationStatement({})).to.be.false
+            expect(esutils.ast.isIterationStatement({type: null})).to.be.false
+            expect(esutils.ast.isIterationStatement({type: undefined})).to.be.false
+
+        it 'returns true if provided node is iteration statement', ->
+            expect(esutils.ast.isIterationStatement({type: "ForInStatement"})).to.be.true
+            expect(esutils.ast.isIterationStatement({type: "DoWhileStatement"})).to.be.true
+
+        it 'returns false if provided node is not iteration statement', ->
+            expect(esutils.ast.isIterationStatement({type: "ExpressionStatement"})).to.be.false
+            expect(esutils.ast.isIterationStatement({type: "ThisExpression"})).to.be.false
+
+
+    describe 'isStatement', ->
+        it 'returns false if input is not node', ->
+            expect(esutils.ast.isStatement(0)).to.be.false
+            expect(esutils.ast.isStatement(null)).to.be.false
+            expect(esutils.ast.isStatement(undefined)).to.be.false
+            expect(esutils.ast.isStatement({})).to.be.false
+            expect(esutils.ast.isStatement({type: null})).to.be.false
+            expect(esutils.ast.isStatement({type: undefined})).to.be.false
+
+        it 'returns true if provided node is statement', ->
+            expect(esutils.ast.isStatement({type: "ExpressionStatement"})).to.be.true
+            expect(esutils.ast.isStatement({type: "WhileStatement"})).to.be.true
+
+        it 'returns false if provided node is not statement', ->
+            expect(esutils.ast.isStatement({type: "ThisExpression"})).to.be.false
+            expect(esutils.ast.isStatement({type: "FunctionDeclaration"})).to.be.false
+            expect(esutils.ast.isStatement({type: "Program"})).to.be.false
+
+
+    describe 'isSourceElement', ->
+        it 'returns false if input is not node', ->
+            expect(esutils.ast.isSourceElement(0)).to.be.false
+            expect(esutils.ast.isSourceElement(null)).to.be.false
+            expect(esutils.ast.isSourceElement(undefined)).to.be.false
+            expect(esutils.ast.isSourceElement({})).to.be.false
+            expect(esutils.ast.isSourceElement({type: null})).to.be.false
+            expect(esutils.ast.isSourceElement({type: undefined})).to.be.false
+
+        it 'returns true if provided node is source element', ->
+            expect(esutils.ast.isSourceElement({type: "ExpressionStatement"})).to.be.true
+            expect(esutils.ast.isSourceElement({type: "WhileStatement"})).to.be.true
+            expect(esutils.ast.isSourceElement({type: "FunctionDeclaration"})).to.be.true
+
+        it 'returns false if provided node is not source element', ->
+            expect(esutils.ast.isSourceElement({type: "ThisExpression"})).to.be.false
+            expect(esutils.ast.isSourceElement({type: "Program"})).to.be.false


### PR DESCRIPTION
Adds `isExpression`, `isStatement`, `isIterationStatement`, and `isSourceElement`. Fixes #7.
