### PR TITLE
Add await as future reserved keyword

### DIFF
--- a/lib/keyword.js
+++ b/lib/keyword.js
@@ -67,7 +67,7 @@
         case 5:
             return (id === 'while') || (id === 'break') || (id === 'catch') ||
                 (id === 'throw') || (id === 'const') || (id === 'yield') ||
-                (id === 'class') || (id === 'super');
+                (id === 'class') || (id === 'super') || (id === 'await');
         case 6:
             return (id === 'return') || (id === 'typeof') || (id === 'delete') ||
                 (id === 'switch') || (id === 'export') || (id === 'import');

--- a/test/keyword.coffee
+++ b/test/keyword.coffee
@@ -46,6 +46,7 @@ KW = [
     'const'
     'class'
     'super'
+    'await'
     'return'
     'typeof'
     'delete'


### PR DESCRIPTION
`await` is (similar to `enum` which is already part of esutils) a future reserved keyword in ES6
http://www.ecma-international.org/ecma-262/6.0/#sec-future-reserved-words

This came up in https://github.com/babel/babel/issues/4198 and babel is using esutils to get the reserved keywords.
