### PR TITLE
Update license to SPDX format

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,7 @@
     "regenerate": "~1.3.1",
     "unicode-9.0.0": "~0.7.0"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/estools/esutils/raw/master/LICENSE.BSD"
-    }
-  ],
+  "licenses": "BSD-2-Clause",
   "scripts": {
     "test": "npm run-script lint && npm run-script unit-test",
     "lint": "jshint lib/*.js",


### PR DESCRIPTION
Update license to correct SPDX format for 'BSD 2-clause "Simplified" License'

Docs.
Yarn: https://yarnpkg.com/lang/en/docs/package-json/#toc-license
NPM: https://docs.npmjs.com/files/package.json#license
SPDX: https://spdx.org/licenses/BSD-2-Clause.html