### PR TITLE
Npm updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.json]
+indent_size = 2
+
+[*.yml]
+indent_size = 2

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/lib/keyword.js
+++ b/lib/keyword.js
@@ -43,14 +43,6 @@
         }
     }
 
-    function isKeywordES5(id, strict) {
-        // yield should not be treated as keyword under non-strict mode.
-        if (!strict && id === 'yield') {
-            return false;
-        }
-        return isKeywordES6(id, strict);
-    }
-
     function isKeywordES6(id, strict) {
         if (strict && isStrictModeReservedWordES6(id)) {
             return true;
@@ -80,6 +72,14 @@
         default:
             return false;
         }
+    }
+
+    function isKeywordES5(id, strict) {
+        // yield should not be treated as keyword under non-strict mode.
+        if (!strict && id === 'yield') {
+            return false;
+        }
+        return isKeywordES6(id, strict);
     }
 
     function isReservedWordES5(id, strict) {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "esutils",
   "description": "utility box for ECMAScript language tools",
   "homepage": "https://github.com/estools/esutils",
+  "bugs": "https://github.com/estools/esutils/issues",
   "main": "lib/utils.js",
   "version": "2.0.4-dev",
   "engines": {
@@ -15,30 +16,35 @@
     "README.md",
     "lib"
   ],
-  "maintainers": [
-    {
-      "name": "Yusuke Suzuki",
-      "email": "utatane.tea@gmail.com",
-      "web": "http://github.com/Constellation"
-    }
+  "keywords": [
+    "ecmascript"
+  ],
+  "author": {
+    "name": "Yusuke Suzuki",
+    "email": "utatane.tea@gmail.com",
+    "web": "http://github.com/Constellation"
+  },
+  "contributors": [
+    "Brett Zamir"
   ],
   "repository": {
     "type": "git",
     "url": "http://github.com/estools/esutils.git"
   },
+  "dependencies": {},
   "devDependencies": {
-    "chai": "~1.7.2",
-    "coffee-script": "~1.6.3",
-    "jshint": "2.6.3",
-    "mocha": "~2.2.1",
-    "regenerate": "~1.3.1",
-    "unicode-9.0.0": "~0.7.0"
+    "chai": "~4.2.0",
+    "coffeescript": "^2.5.1",
+    "jshint": "2.11.0",
+    "mocha": "~7.1.2",
+    "regenerate": "~1.4.0",
+    "unicode-13.0.0": "^0.8.0"
   },
   "license": "BSD-2-Clause",
   "scripts": {
-    "test": "npm run-script lint && npm run-script unit-test",
+    "test": "npm run lint && npm run unit-test",
     "lint": "jshint lib/*.js",
-    "unit-test": "mocha --compilers coffee:coffee-script -R spec",
+    "unit-test": "mocha --require chai/register-expect --require coffeescript/register test/**",
     "generate-regex": "node tools/generate-identifier-regex.js"
   }
 }

--- a/test/ast.coffee
+++ b/test/ast.coffee
@@ -22,7 +22,6 @@
 
 'use strict'
 
-expect = require('chai').expect
 esutils = require '../'
 
 EMPTY = {type: 'EmptyStatement'}

--- a/test/code.coffee
+++ b/test/code.coffee
@@ -22,7 +22,6 @@
 
 'use strict'
 
-expect = require('chai').expect
 esutils = require '../'
 
 describe 'code', ->

--- a/test/keyword.coffee
+++ b/test/keyword.coffee
@@ -22,7 +22,6 @@
 
 'use strict'
 
-expect = require('chai').expect
 esutils = require '../'
 
 KW = [

--- a/tools/generate-identifier-regex.js
+++ b/tools/generate-identifier-regex.js
@@ -4,11 +4,14 @@
 const regenerate = require('regenerate');
 
 // Which Unicode version should be used?
-const version = '9.0.0';
+const pkg = require('../package.json');
+const dependencies = Object.keys(pkg.devDependencies);
+const unicodeDep = dependencies.find((name) => /^unicode-\d/.test(name));
+const version = unicodeDep.match(/[^\d]+(.+)$/)[1];
 
 // Set up a shorthand function to import Unicode data.
 const get = function(what) {
-    return require('unicode-' + version + '/' + what + '/code-points');
+    return require('unicode-' + version + '/' + what + '/code-points.js');
 };
 
 // Get the Unicode categories needed to construct the ES5 regex.


### PR DESCRIPTION
- Update to Unicoode 13; closes #27
- Linting: As per latest jshint (define function before called)
- Testing: Use chai's `register-expect`
- npm: Update devDeps (including moving from `coffee-script` to non-deprecated `coffeescript`)
- npm: Simplify script running
- npm: Avoid adding `package-lock.json`
- npm: Update mocha per latest API
- npm: Add recommended package.json fields: keywords, bugs, dependencies and change to author/contributors
- Maintenance: Add `.editorconfig`

(I have a PR built on top of this I intend to submit next which replaces jshint with eslint and replaces coffeescript entirely, but trying to keep it more atomic.)